### PR TITLE
Fix dead link to API Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ With [Maven](http://maven.apache.org), add the following to your `pom.xml` file:
 
 ## Reference
 
-[API Documentation](http://edn-format.github.com/data.edn)
+[API Documentation](http://edn-format.github.io/data.edn)
 
 ## Rationale
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ With [Maven](http://maven.apache.org), add the following to your `pom.xml` file:
 
 ## Reference
 
-[API Documentation](http://edn-format.github.io/data.edn)
+[API Documentation](https://edn-format.github.io/data.edn)
 
 ## Rationale
 


### PR DESCRIPTION
Hi! I believe I found a dead link.

Link to API docs in current README: http://edn-format.github.com/data.edn
Where I assume the link should be pointing: https://edn-format.github.io/data.edn